### PR TITLE
fix: Add arguments disabling CORS

### DIFF
--- a/selenosis/__init__.py
+++ b/selenosis/__init__.py
@@ -8,7 +8,7 @@
 import sys
 from types import ModuleType
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 # import mapping to objects in other modules
 all_by_module = {

--- a/selenosis/selenium.py
+++ b/selenosis/selenium.py
@@ -127,6 +127,8 @@ class SelenosisTestCaseBase(type(LiveServerTestCase)):
             options.add_argument('headless')
             options.add_argument('disable-gui')
             options.add_argument('no-sandbox')
+            options.add_argument('disable-web-security')
+            options.add_argument('--disable-features=IsolateOrigins,site-per-process')
             if os.environ.get('DISABLE_DEV_SHM_USAGE'):
                 options.add_argument('disable-dev-shm-usage')
             if os.environ.get('CHROME_BIN'):

--- a/selenosis/selenium.py
+++ b/selenosis/selenium.py
@@ -127,12 +127,14 @@ class SelenosisTestCaseBase(type(LiveServerTestCase)):
             options.add_argument('headless')
             options.add_argument('disable-gui')
             options.add_argument('no-sandbox')
-            options.add_argument('disable-web-security')
-            options.add_argument('--disable-features=IsolateOrigins,site-per-process')
             if os.environ.get('DISABLE_DEV_SHM_USAGE'):
                 options.add_argument('disable-dev-shm-usage')
             if os.environ.get('CHROME_BIN'):
                 options.binary_location = os.environ['CHROME_BIN']
+            if os.environ.get('DISABLE_WEB_SECURITY'):
+                options.add_argument('disable-web-security')
+                options.add_argument('--disable-features=IsolateOrigins,site-per-process')
+
 
             kwargs['options'] = options
 


### PR DESCRIPTION
Some build are currently failing because of CORS rules. It seems like `chrome-headless` was updated and enforces CORS by default. So we need to add these arguments to be able to run selenium tests correctly.