### PR TITLE
fix: Django 5.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,24 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        grappelli: ["0", "1"]
-        python-version: ["3.11"]
-        django-version: ["4.2"]
-        exclude:
-          - python-version: "3.11"
-            grappelli: "1"
         include:
           - python-version: "3.8"
             django-version: "4.2"
-            grappelli: "1"
-          - python-version: "3.9"
-            django-version: "5.0"
             grappelli: "0"
-          - python-version: "3.10"
-            django-version: "5.0"
+          - python-version: "3.9"
+            django-version: "4.2"
             grappelli: "1"
-          - python-version: "3.12"
+          - python-version: "3.11"
             django-version: "5.1"
+            grappelli: "1"
+          - python-version: "3.13"
+            django-version: "5.2"
             grappelli: "0"
 
     name: Django ${{ matrix.django-version }} (Python ${{ matrix.python-version }})${{ matrix.grappelli == '1' && ' + grappelli' || '' }}

--- a/selenosis/testcases.py
+++ b/selenosis/testcases.py
@@ -12,7 +12,7 @@ from django.urls import reverse
 from django.test.utils import override_settings
 
 from .selenium import SelenosisTestCaseBase, SelenosisTestCase
-from .utils import tag
+from .utils import tag, class_property
 
 
 class AdminSelenosisTestCaseBase(SelenosisTestCaseBase):
@@ -190,16 +190,16 @@ class AdminSelenosisTestCase(
     admin_site_name = 'admin'
     auto_login = True
 
-    @property
-    def has_grappelli(self):
+    @class_property
+    def has_grappelli(cls):
         return 'grappelli' in settings.INSTALLED_APPS
 
-    @property
-    def has_suit(self):
+    @class_property
+    def has_suit(cls):
         return 'suit' in settings.INSTALLED_APPS
 
-    @property
-    def available_apps(self):
+    @class_property
+    def available_apps(cls):
         apps = [
             'django.contrib.auth',
             'django.contrib.contenttypes',
@@ -210,10 +210,10 @@ class AdminSelenosisTestCase(
             'django.contrib.admin',
             'selenosis',
         ]
-        if self.has_grappelli:
+        if cls.has_grappelli:
             apps.insert(0, 'grappelli')
 
-        current_app = type(self).__module__.rpartition('.')[0]
+        current_app = cls.__module__.rpartition('.')[0]
 
         parent_app = re.split(r'\.tests(?:\.|$)', current_app)[0]
         if parent_app != current_app:

--- a/selenosis/utils.py
+++ b/selenosis/utils.py
@@ -1,6 +1,23 @@
 def tag(*tags):
     """Decorator to add tags to a test class or method."""
+
     def decorator(obj):
-        setattr(obj, 'tags', set(tags))
+        setattr(obj, "tags", set(tags))
         return obj
+
     return decorator
+
+
+class class_property:
+    "Like the property builtin, but as a classmethod"
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, obj, objtype=None):
+        if obj is None and objtype is None:
+            return self
+        objtype = objtype or type(obj)
+        if self.fget is None:
+            raise AttributeError
+        return self.fget(objtype)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{36,37,38,39,310}-dj32-{grp,nogrp}
     py{38,39,310,311,312}-dj42-{grp,nogrp}
     py{310,311,312}-dj50-{grp,nogrp}
-    py{310,311,312}-dj51-nogrp
+    py{310,311,312,313}-{dj51,dj52}-{grp,nogrp}
 
 [testenv]
 commands =
@@ -18,11 +18,14 @@ deps =
     dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
-    dj51: Django>=5.1a1,<5.2
+    dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     dj22-grp: django-grappelli>=2.13,<2.14
     dj32-grp: django-grappelli>=2.15,<2.16
     dj42-grp: django-grappelli>=3.0,<3.1
     dj50-grp: django-grappelli>=4.0,<4.1
+    dj51-grp: django-grappelli>=4.0,<4.1
+    dj52-grp: django-grappelli>=4.0,<4.1
 
 [testenv:clean]
 description = Clean all build and test artifacts
@@ -47,6 +50,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
@@ -55,6 +59,7 @@ DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
 GRAPPELLI =
     0: nogrp
     1: grp


### PR DESCRIPTION
In Django 5.2, the test runner gets the `available_apps` off the class, not the instance. With a normal `property` this would return the `property` object itself. To accommodate this change, `available_apps` can now be accessed from the class.